### PR TITLE
Update for container image vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN dotnet build
 RUN dotnet publish --runtime alpine-x64 -c Release -o out --self-contained true /p:PublishTrimmed=true
 
 # build runtime image
-FROM cingulara/openrmf-base:1.04.00
+FROM cingulara/openrmf-base:1.08.02
 RUN apk update && apk upgrade
 
 RUN mkdir /app

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.01
+VERSION ?= 1.08.02
 NAME ?= "openrmf-msg-controls"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 1.08.00
+VERSION ?= 1.08.01
 NAME ?= "openrmf-msg-controls"
 AUTHOR ?= "Dale Bingham"
 NO_CACHE ?= true

--- a/src/openrmf-msg-controls.csproj
+++ b/src/openrmf-msg-controls.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_controls</RootNamespace>
     <ProjectGuid>{083a705d-1c68-4580-8905-a52ea2a61775}</ProjectGuid>
-    <Version>1.08.01</Version>
+    <Version>1.08.02</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Messaging API for sending NIST control data via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 
@@ -23,6 +23,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/openrmf-msg-controls.csproj
+++ b/src/openrmf-msg-controls.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>openrmf_msg_controls</RootNamespace>
     <ProjectGuid>{083a705d-1c68-4580-8905-a52ea2a61775}</ProjectGuid>
-    <Version>1.07.00</Version>
+    <Version>1.08.01</Version>
     <InformationalVersion>This is the OpenRMF OSS Application Messaging API for sending NIST control data via messaging from Cingulara</InformationalVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
Commits on Aug 28, 2022
[update to latest base image](https://github.com/Cingulara/openrmf-msg-controls/commit/da1b6d7b72cc478ac42ff75d900522428d07e4fd)

Commits on Nov 27, 2022
[updating vulnerability information for v1.8.3](https://github.com/Cingulara/openrmf-msg-controls/commit/599aedaeead091c367c84c013030d6123ffb8740)